### PR TITLE
Fixed curl download file command

### DIFF
--- a/haa_downloader.sh
+++ b/haa_downloader.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-#       /------------------------------------------------------------------------\
+#       /-----------------------------------------------------------------------\
 #       | HAA Binary File Downloader,                                           |
 #       | Useful for downloading HAA Binary files for custom OTA update servers |
 #       | Copyright (C) 2020 AJAX                                               |
@@ -18,32 +18,32 @@
 #       \-----------------------------------------------------------------------/
 #
 download_haa(){
-        echo "--------------------------------------------------------"
-        echo
-        version_meta=$(curl -s "https://api.github.com/repos/$owner/$repository/releases/tags/$version")
-        validation=$(echo "$version_meta" | grep -Po '(?<="message": ")[^"]*')
-        files=($(echo "$version_meta" | grep -Po '(?<="browser_download_url": ")[^"]*'))
+	echo "--------------------------------------------------------"
+	echo
+	version_meta=$(curl -s "https://api.github.com/repos/$owner/$repository/releases/tags/$version")
+	validation=$(echo "$version_meta" | grep -Po '(?<="message": ")[^"]*')
+	files=($(echo "$version_meta" | grep -Po '(?<="browser_download_url": ")[^"]*'))
 
-        if [ -z "$validation" ]
-        then
-                if [ ! -d "$version" ]; then
-                        mkdir "$version"
-                fi
-                for i in "${files[@]}"
-                do
-                        file_name="$(basename $i)"
-                        echo -n "Saving ./$version/$file_name ... "
-                        curl -s "$i" > "./$version/$file_name"
-                        if [ "$?" -ne 0 ]
-                        then
-                                echo "Failed to retrieve, check connection or user permissions"
-                        else
-                                echo "Done"
-                        fi
-                done
-        else
-                echo "Incorrect Version?"
-        fi
+	if [ -z "$validation" ]
+	then
+		if [ ! -d "$version" ]; then
+			mkdir "$version"
+		fi
+		for i in "${files[@]}"
+		do
+			file_name="$(basename $i)"
+			echo -n "Saving ./$version/$file_name ... "
+			curl -sLo "./$version/$file_name" "$i"
+			if [ "$?" -ne 0 ]
+			then
+				echo "Failed to retrieve, check connection or user permissions"
+			else
+				echo "Done"
+			fi
+		done
+	else
+		echo "Incorrect Version?"
+	fi
 }
 owner="RavenSystem"
 repository="haa"
@@ -57,19 +57,19 @@ See the GNU General Public License for more details."
 echo "============================================================="
 echo
 if [ -n "$1" ]; then
-        version="$1"
-        echo "Attempting to download the specified verion: $version"
-        download_haa
+	version="$1"
+	echo "Attempting to download the specified verion: $version"
+	download_haa
 else
-        version=$(curl -s "https://api.github.com/repos/$owner/$repository/releases/latest" | grep -Po '(?<="tag_name": ")[^"]*')
-        echo "Attempting to download the latest version: $version"
-        download_haa
-        echo
-        echo -n "Copying latest files to: "
-        pwd
-        echo "--------------------------------------------------------"
-        echo
-        cp -v ./"$version"/* ./
+	version=$(curl -s "https://api.github.com/repos/$owner/$repository/releases/latest" | grep -Po '(?<="tag_name": ")[^"]*')
+	echo "Attempting to download the latest version: $version"
+	download_haa
+	echo
+	echo -n "Copying latest files to: "
+	pwd
+	echo "--------------------------------------------------------"
+	echo
+	cp -v ./"$version"/* ./
 fi
 echo
 rate_limit=$(curl -s "https://api.github.com/rate_limit" | grep -Pom 1 '(?<="limit": )[^,}]*')


### PR DESCRIPTION
curl command to download files was retrieving the redirect rather than the file itself, updated to use the -L flag
changed git client, spaces now replaced with tabs